### PR TITLE
Update CI workflows and project for symbol packages and source link

### DIFF
--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -3,10 +3,10 @@ name: Build and Publish Preview NuGet Package
 on:
   push:
     branches:
-      - development
+      - Development
   pull_request:
     branches:
-      - development
+      - Development
 
 jobs:
   build:
@@ -31,7 +31,7 @@ jobs:
       run: dotnet test --no-restore --verbosity normal
 
   publish:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/development'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/Development'
     needs: build
     runs-on: windows-latest
 
@@ -50,10 +50,15 @@ jobs:
     - name: Build the solution
       run: dotnet build --configuration Release --no-restore
 
-    - name: Pack Preview NuGet package
-      run: dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "${{ github.workspace }}\output" /p:PackageVersion=$(git describe --tags --abbrev=0)-preview
+    - name: Pack Preview NuGet package (with symbols)
+      run: dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "${{ github.workspace }}\output" /p:PackageVersion=$(git describe --tags --abbrev=0)-preview /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
 
     - name: Publish Preview NuGet package
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
       run: dotnet nuget push "${{ github.workspace }}\output\*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+    - name: Publish Symbol Package (.snupkg)
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      run: dotnet nuget push "${{ github.workspace }}\output\*.snupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,4 @@
-name: Build and Publish NuGet Package
+name: Build and Publish Final NuGet Package
 
 on:
   push:
@@ -50,10 +50,15 @@ jobs:
     - name: Build the solution
       run: dotnet build --configuration Release --no-restore
 
-    - name: Pack NuGet package
-      run: dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "${{ github.workspace }}\output"
+    - name: Pack Final NuGet package (with symbols)
+      run: dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "${{ github.workspace }}\output" /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
 
-    - name: Publish NuGet package
+    - name: Publish Final NuGet package
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
       run: dotnet nuget push "${{ github.workspace }}\output\*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+
+    - name: Publish Symbol Package (.snupkg)
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      run: dotnet nuget push "${{ github.workspace }}\output\*.snupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj
+++ b/Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Version>1.0.2</Version>
+		<Version>1.0.3</Version>
 		<Authors>Bert Berrevoets</Authors>
 		<Company>Berrevoets Systems</Company>
 		<Product>Berrevoets.MonitoredBackgroundService</Product>
@@ -11,7 +11,15 @@
 		<PackageTags>BackgroundService;HealthMonitoring;HostedService</PackageTags>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
 		<RepositoryUrl>https://github.com/bberrevoets/MonitoredBackgroundService</RepositoryUrl>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<EnableSourceLink>true</EnableSourceLink>
+		<DebugType>portable</DebugType>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<ImplicitUsings>enable</ImplicitUsings>
+		<Deterministic>true</Deterministic>
+		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 		<Nullable>enable</Nullable>
 		<!-- Add License Information -->
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile> <!-- This should match the filename you use -->
@@ -31,6 +39,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Update GitHub Actions workflows to handle case sensitivity in branch names.
- Modify `CI-development.yml` and `CI.yml` to include symbol packages during NuGet package creation and publishing.
- Increment version in `Berrevoets.MonitoredBackgroundService.csproj` from `1.0.2` to `1.0.3`.
- Add properties for source link and deterministic builds in the project file.
- Add package reference to `Microsoft.SourceLink.GitHub` for source link support.