### PR TITLE
Update CI pipeline for version extraction and packaging

### DIFF
--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -49,14 +49,18 @@ jobs:
 
     - name: Extract version from .csproj and append -preview
       id: extract-version
+      shell: bash
       run: |
-        $version = (dotnet msbuild -nologo -property:Version Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj | Select-String -Pattern "([0-9]+\.[0-9]+\.[0-9]+)" | ForEach-Object { $_.Matches[0].Value })
-        echo "Version extracted: $version-preview"
-        echo "##[set-output name=VERSION;]$version-preview"
-
+        VERSION=$(dotnet msbuild -nologo -property:Version Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj | grep -oP '([0-9]+\.[0-9]+\.[0-9]+)')
+        if [ -z "$VERSION" ]; then
+          echo "Error: Version could not be extracted."
+          exit 1
+        fi
+        echo "Version extracted: $VERSION-preview"
+        echo "VERSION=$VERSION-preview" >> $GITHUB_ENV
 
     - name: Pack Preview NuGet package (with symbols)
-      run: dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "${{ github.workspace }}\output" /p:PackageVersion=${{ steps.extract-version.outputs.VERSION }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
+      run: dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "${{ github.workspace }}\output" /p:PackageVersion=${{ env.VERSION }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
 
     - name: Publish Preview NuGet package
       env:


### PR DESCRIPTION
- Modify `CI-development.yml` to improve version extraction steps
- Use a robust Bash script with `grep` and error handling
- Set extracted version as `VERSION` env variable via `GITHUB_ENV`
- Update `Pack Preview NuGet package` step to use `${{ env.VERSION }}`
- Enhance reliability and compatibility with GitHub Actions best practices