### PR TITLE
Switch regex in CI from Perl-compatible to extended

### DIFF
--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -51,7 +51,7 @@ jobs:
       id: extract-version
       shell: bash
       run: |
-        VERSION=$(dotnet msbuild -nologo -property:Version Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj | grep -oP '([0-9]+\.[0-9]+\.[0-9]+)')
+        VERSION=$(dotnet msbuild -nologo -property:Version Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
         if [ -z "$VERSION" ]; then
           echo "Error: Version could not be extracted."
           exit 1


### PR DESCRIPTION
Updated the regex used to extract the version number from the `.csproj` file in the CI pipeline. Changed from `grep -oP '([0-9]+\.[0-9]+\.[0-9]+)'` to `grep -Eo '[0-9]+\.[0-9]+\.[0-9]+'`, switching from Perl-compatible (`-oP`) to extended regular expressions (`-Eo`).