### PR TITLE
Simplify .NET setup and standardize version reference

### DIFF
--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -56,18 +56,18 @@ jobs:
           exit 1
         fi
         VERSION="$VERSION-preview"
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
         echo "Version extracted: $VERSION"
-        echo "{name}={value}" >> $GITHUB_ENV
 
     - name: Build the solution (Release) again for packaging
       run: |
-        echo "Building NuGet package with version: $VERSION"
-        dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release /p:PackageVersion=$VERSION
+        echo "Building NuGet package with version: ${{ env.VERSION }}"
+        dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release /p:PackageVersion=${{ env.VERSION }}
 
     - name: Pack Preview NuGet package (with symbols)
       run: |
-        echo "Packing NuGet package with version: $VERSION"
-        dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "./output" /p:PackageVersion=$VERSION /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
+        echo "Packing NuGet package with version: ${{ env.VERSION }}"
+        dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "./output" /p:PackageVersion=${{ env.VERSION }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
 
     - name: Publish Preview NuGet package
       env:

--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -61,17 +61,17 @@ jobs:
 
     - name: Use extracted version from build job
       run: |
-        VERSION="${{ needs.build.outputs.version }}"
-        echo "VERSION=$VERSION"
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
+          $env:VERSION = "${{ needs.build.outputs.version }}"
+          echo "VERSION=$env:VERSION"
+          echo "VERSION=$env:VERSION" >> $GITHUB_ENV
 
     - name: Build the solution (Release) again for packaging
       run: dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release
 
     - name: Pack Preview NuGet package (with symbols)
       run: |
-        echo "Packing NuGet package with version: $VERSION"
-        dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "./output" /p:PackageVersion=$VERSION /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
+        echo "Packing NuGet package with version: $env:VERSION"
+        dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "./output" /p:PackageVersion=$env:VERSION /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
 
     - name: Publish Preview NuGet package
       env:

--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -67,14 +67,14 @@ jobs:
     - name: Pack Preview NuGet package (with symbols)
       run: |
         echo "Packing NuGet package with version: ${{ env.VERSION }}"
-        dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "./output" /p:PackageVersion=${{ env.VERSION }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
+        dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "${{ github.workspace }}/output" /p:PackageVersion=${{ env.VERSION }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
 
     - name: Publish Preview NuGet package
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: dotnet nuget push "./output/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push "${{ github.workspace }}/output/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
     - name: Publish Symbol Package (.snupkg)
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: dotnet nuget push "./output/*.snupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push "${{ github.workspace }}/output/*.snupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -73,7 +73,7 @@ jobs:
         echo "version=$VERSION" >> $GITHUB_ENV
 
     - name: Build the solution (Release) again for packaging
-      run: dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release
+      run: dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release /p:PackageVersion=$VERSION
 
     - name: Pack Preview NuGet package (with symbols)
       run: |

--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -60,9 +60,7 @@ jobs:
       run: dotnet restore
 
     - name: Use extracted version from build job
-      run: |
-        echo "VERSION=${{ needs.build.outputs.version }}" >> $GITHUB_ENV
-        echo "VERSION=${{ needs.build.outputs.version }}"
+      run: echo "VERSION=${{ needs.build.outputs.version }}" >> $GITHUB_ENV
 
     - name: Build the solution (Release) again for packaging
       run: dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release

--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -36,7 +36,7 @@ jobs:
         fi
         VERSION="$VERSION-preview"
         echo "Version extracted: $VERSION"
-        echo "version=$VERSION" >> $GITHUB_ENV
+        echo "::set-output name=version::$VERSION"
 
     - name: Build the solution (Release)
       run: dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release
@@ -59,17 +59,8 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
 
-    - name: Extract version from .csproj and append -preview
-      id: extract-version
-      shell: bash
-      run: |
-        VERSION=$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj)
-        if [ -z "$VERSION" ]; then
-          echo "Error: Version could not be extracted."
-          exit 1
-        fi
-        VERSION="$VERSION-preview"
-        echo "Version extracted: $VERSION"
+    - name: Use extracted version from build job
+      run: echo "VERSION=${{ needs.build.outputs.version }}" >> $GITHUB_ENV
 
     - name: Build the solution (Release) again for packaging
       run: dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release /p:PackageVersion=$VERSION

--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -1,4 +1,5 @@
 name: Build and Publish Preview NuGet Package
+
 on:
   push:
     branches:
@@ -10,10 +11,8 @@ on:
 jobs:
   build:
     runs-on: windows-latest
-
     outputs:
       version: ${{ steps.extract-version.outputs.version }}
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -35,8 +34,9 @@ jobs:
           echo "Error: Version could not be extracted."
           exit 1
         fi
-        VERSION="${VERSION}-preview"
+        VERSION="$VERSION-preview"
         echo "Version extracted: $VERSION"
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
         echo "::set-output name=version::$VERSION"
 
     - name: Build the solution (Release)
@@ -48,7 +48,6 @@ jobs:
   publish:
     needs: build
     runs-on: windows-latest
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -63,9 +62,9 @@ jobs:
 
     - name: Use extracted version from build job
       run: |
+        echo "VERSION=${{ needs.build.outputs.version }}"
         echo "VERSION=${{ needs.build.outputs.version }}" >> $GITHUB_ENV
-        echo "VERSION=${{ env.VERSION }}"
-        
+
     - name: Build the solution (Release) again for packaging
       run: dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release
 

--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -67,14 +67,14 @@ jobs:
     - name: Pack Preview NuGet package (with symbols)
       run: |
         echo "Packing NuGet package with version: ${{ env.VERSION }}"
-        dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "${{ github.workspace }}/output" /p:PackageVersion=${{ env.VERSION }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
+        dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "${{ github.workspace }}\output" /p:PackageVersion=${{ env.VERSION }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
 
     - name: Publish Preview NuGet package
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: dotnet nuget push "${{ github.workspace }}/output/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push "${{ github.workspace }}\output\*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
     - name: Publish Symbol Package (.snupkg)
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: dotnet nuget push "${{ github.workspace }}/output/*.snupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push "${{ github.workspace }}\output\*.snupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -70,7 +70,6 @@ jobs:
         fi
         VERSION="$VERSION-preview"
         echo "Version extracted: $VERSION"
-        echo "version=$VERSION" >> $GITHUB_ENV
 
     - name: Build the solution (Release) again for packaging
       run: dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release /p:PackageVersion=$VERSION

--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -60,10 +60,14 @@ jobs:
       run: dotnet restore
 
     - name: Use extracted version from build job
-      run: echo "VERSION=${{ needs.build.outputs.version }}" >> $GITHUB_ENV
+      run: |
+        echo "VERSION=${{ needs.build.outputs.version }}" >> $GITHUB_ENV
+        echo "Version set to: $VERSION"
 
     - name: Build the solution (Release) again for packaging
-      run: dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release /p:PackageVersion=$VERSION
+      run: |
+        echo "Building NuGet package with version: $VERSION"
+        dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release /p:PackageVersion=$VERSION
 
     - name: Pack Preview NuGet package (with symbols)
       run: |

--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -57,7 +57,7 @@ jobs:
         fi
         VERSION="$VERSION-preview"
         echo "Version extracted: $VERSION"
-        echo "::set-output name=version::$VERSION"
+        echo "{name}={value}" >> $GITHUB_ENV
 
     - name: Build the solution (Release) again for packaging
       run: |

--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '8.0.x' # Adjust according to your project's target framework
+        dotnet-version: '8.0.x'
 
     - name: Restore dependencies
       run: dotnet restore
@@ -56,7 +56,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '8.0.x' # Adjust according to your project's target framework
+        dotnet-version: '8.0.x'
 
     - name: Restore dependencies
       run: dotnet restore
@@ -68,7 +68,7 @@ jobs:
       run: dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release
 
     - name: Pack Preview NuGet package (with symbols)
-      run: dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "${{ github.workspace }}\output" /p:PackageVersion=${{ env.VERSION }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
+      run: dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "${{ github.workspace }}\output" /p:PackageVersion=$VERSION /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
 
     - name: Publish Preview NuGet package
       env:

--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -36,7 +36,7 @@ jobs:
         fi
         VERSION="$VERSION-preview"
         echo "Version extracted: $VERSION"
-        echo "::set-output name=version::$VERSION"
+        echo "version=$VERSION" >> $GITHUB_ENV
 
     - name: Build the solution (Release)
       run: dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release
@@ -61,17 +61,16 @@ jobs:
 
     - name: Use extracted version from build job
       run: |
-          $env:VERSION = "${{ needs.build.outputs.version }}"
-          echo "VERSION=$env:VERSION"
-          echo "VERSION=$env:VERSION" >> $GITHUB_ENV
+        echo "VERSION=${{ needs.build.outputs.version }}" >> $GITHUB_ENV
+        echo "VERSION=${{ needs.build.outputs.version }}"
 
     - name: Build the solution (Release) again for packaging
       run: dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release
 
     - name: Pack Preview NuGet package (with symbols)
       run: |
-        echo "Packing NuGet package with version: $env:VERSION"
-        dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "./output" /p:PackageVersion=$env:VERSION /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
+        echo "Packing NuGet package with version: $VERSION"
+        dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "./output" /p:PackageVersion=$VERSION /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
 
     - name: Publish Preview NuGet package
       env:

--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -1,5 +1,4 @@
 name: Build and Publish Preview NuGet Package
-
 on:
   push:
     branches:
@@ -36,8 +35,9 @@ jobs:
           echo "Error: Version could not be extracted."
           exit 1
         fi
-        echo "Version extracted: $VERSION-preview"
-        echo "::set-output name=version::$VERSION-preview"
+        VERSION="${VERSION}-preview"
+        echo "Version extracted: $VERSION"
+        echo "::set-output name=version::$VERSION"
 
     - name: Build the solution (Release)
       run: dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release
@@ -62,13 +62,15 @@ jobs:
       run: dotnet restore
 
     - name: Use extracted version from build job
-      run: echo "VERSION=${{ needs.build.outputs.version }}" >> $GITHUB_ENV
-
+      run: |
+        echo "VERSION=${{ needs.build.outputs.version }}" >> $GITHUB_ENV
+        echo "VERSION=${{ env.VERSION }}"
+        
     - name: Build the solution (Release) again for packaging
       run: dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release
 
     - name: Pack Preview NuGet package (with symbols)
-      run: dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "${{ github.workspace }}\output" /p:PackageVersion=$VERSION /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
+      run: dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "${{ github.workspace }}\output" /p:PackageVersion=${{ env.VERSION }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
 
     - name: Publish Preview NuGet package
       env:

--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -62,21 +62,24 @@ jobs:
 
     - name: Use extracted version from build job
       run: |
-        echo "VERSION=${{ needs.build.outputs.version }}"
         echo "VERSION=${{ needs.build.outputs.version }}" >> $GITHUB_ENV
+        echo "VERSION=${{ env.VERSION }}"
+      shell: bash
 
     - name: Build the solution (Release) again for packaging
       run: dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release
 
     - name: Pack Preview NuGet package (with symbols)
-      run: dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "${{ github.workspace }}\output" /p:PackageVersion=${{ env.VERSION }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
+      run: |
+        echo "Packing NuGet package with version: $VERSION"
+        dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "${{ github.workspace }}/output" /p:PackageVersion=${{ env.VERSION }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
 
     - name: Publish Preview NuGet package
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: dotnet nuget push "${{ github.workspace }}\output\*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push "${{ github.workspace }}/output/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
     - name: Publish Symbol Package (.snupkg)
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: dotnet nuget push "${{ github.workspace }}\output\*.snupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push "${{ github.workspace }}/output/*.snupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -36,7 +36,6 @@ jobs:
         fi
         VERSION="$VERSION-preview"
         echo "Version extracted: $VERSION"
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
         echo "::set-output name=version::$VERSION"
 
     - name: Build the solution (Release)
@@ -62,9 +61,9 @@ jobs:
 
     - name: Use extracted version from build job
       run: |
-        echo "VERSION=${{ needs.build.outputs.version }}" >> $GITHUB_ENV
-        echo "VERSION=${{ env.VERSION }}"
-      shell: bash
+        VERSION="${{ needs.build.outputs.version }}"
+        echo "VERSION=$VERSION"
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
 
     - name: Build the solution (Release) again for packaging
       run: dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release
@@ -72,14 +71,14 @@ jobs:
     - name: Pack Preview NuGet package (with symbols)
       run: |
         echo "Packing NuGet package with version: $VERSION"
-        dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "${{ github.workspace }}/output" /p:PackageVersion=${{ env.VERSION }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
+        dotnet pack Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release --output "./output" /p:PackageVersion=$VERSION /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
 
     - name: Publish Preview NuGet package
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: dotnet nuget push "${{ github.workspace }}/output/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push "./output/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
     - name: Publish Symbol Package (.snupkg)
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: dotnet nuget push "${{ github.workspace }}/output/*.snupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push "./output/*.snupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -25,19 +25,6 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
 
-    - name: Extract version from .csproj and append -preview
-      id: extract-version
-      shell: bash
-      run: |
-        VERSION=$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj)
-        if [ -z "$VERSION" ]; then
-          echo "Error: Version could not be extracted."
-          exit 1
-        fi
-        VERSION="$VERSION-preview"
-        echo "Version extracted: $VERSION"
-        echo "::set-output name=version::$VERSION"
-
     - name: Build the solution (Release)
       run: dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release
 
@@ -59,10 +46,18 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
 
-    - name: Use extracted version from build job
+    - name: Extract version from .csproj and append -preview
+      id: extract-version
+      shell: bash
       run: |
-        echo "VERSION=${{ needs.build.outputs.version }}" >> $GITHUB_ENV
-        echo "Version set to: $VERSION"
+        VERSION=$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj)
+        if [ -z "$VERSION" ]; then
+          echo "Error: Version could not be extracted."
+          exit 1
+        fi
+        VERSION="$VERSION-preview"
+        echo "Version extracted: $VERSION"
+        echo "::set-output name=version::$VERSION"
 
     - name: Build the solution (Release) again for packaging
       run: |

--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -59,8 +59,18 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
 
-    - name: Use extracted version from build job
-      run: echo "VERSION=${{ needs.build.outputs.version }}" >> $GITHUB_ENV
+    - name: Extract version from .csproj and append -preview
+      id: extract-version
+      shell: bash
+      run: |
+        VERSION=$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj)
+        if [ -z "$VERSION" ]; then
+          echo "Error: Version could not be extracted."
+          exit 1
+        fi
+        VERSION="$VERSION-preview"
+        echo "Version extracted: $VERSION"
+        echo "version=$VERSION" >> $GITHUB_ENV
 
     - name: Build the solution (Release) again for packaging
       run: dotnet build Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj --configuration Release


### PR DESCRIPTION
Removed the `dotnet-version` comment for clarity in the `Set up .NET` step. Updated the `Pack Preview NuGet package (with symbols)` step to use `$VERSION` instead of `${{ env.VERSION }}` for the `PackageVersion` property, ensuring consistency in environment variable usage.