### PR TITLE
Update CI config and bump version to 1.1.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,9 +56,9 @@ jobs:
     - name: Publish Final NuGet package
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: dotnet nuget push "${{ github.workspace }}\output\*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push "${{ github.workspace }}\output\*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
     - name: Publish Symbol Package (.snupkg)
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: dotnet nuget push "${{ github.workspace }}\output\*.snupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push "${{ github.workspace }}\output\*.snupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj
+++ b/Berrevoets.MonitoredBackgroundService/Berrevoets.MonitoredBackgroundService.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Version>1.0.3</Version>
+		<Version>1.1.0</Version>
 		<Authors>Bert Berrevoets</Authors>
 		<Company>Berrevoets Systems</Company>
 		<Product>Berrevoets.MonitoredBackgroundService</Product>


### PR DESCRIPTION
- Add `--skip-duplicate` flag to CI.yml for NuGet push to prevent errors if the package already exists.
- Update `Berrevoets.MonitoredBackgroundService.csproj` version from 1.0.3 to 1.1.0, indicating a new release with potential new features or significant changes.